### PR TITLE
Remove default use of the environment for expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,27 +76,27 @@ p := procs.NewProcess("echo $FOO")
 p.Env = map[string]string{"FOO": "foo"}
 ```
 
-Also, environment variables will be expanded automatically using the
-`os.Expand` semantics and the provided environment.
+Also, environment variables defined by the `Process.Env` can be
+expanded automatically using the `os.Expand` semantics and the
+provided environment.
 
-Note that **if no environment is provided, the parent process
-environment is used**. It is recommended to be explicit with your
-environment variables as they can be used in replacements within the
-commands. Again, you can predefine the `exec.Cmd` to avoid this
-replacement.
-
-There is also a `Env` function that can help to merge an existing
-environment with the parent environment to allow overriding parent
-variables.
+There is a `ParseEnv` function that can help to merge the parent
+processes' environment with any new values.
 
 ```go
-myenv := map[string]string{"USER": "foo"}
-env := ParseEnv(Env(myenv, true))
+env := ParseEnv(os.Environ())
+env["USER"] = "foo"
 ```
 
-The `Env` function will overlay the passed in environment with the
-parent environment and `ParseEnv` takes a environment `[]string` and
-converts it to a `map[string]string` for use with a Proc.
+Finally, if you are building commands manually, the `Env` function can
+take a `map[string]string` and convert it to a `[]string` for use with
+an `exec.Cmd`. The `Env` function also accepts a `useEnv` bool to help
+include the parent process environment.
+
+```go
+cmd := exec.Command("knife", "cookbook", "show", cb)
+cmd.Env = Env(map[string]string{"USER": "knife-user"}, true)
+```
 
 ## Example Applications
 

--- a/parse.go
+++ b/parse.go
@@ -12,7 +12,7 @@ import (
 // like a shell, returning a []string that can be used as arguments to
 // exec.Command.
 func SplitCommand(cmd string) []string {
-	return SplitCommandEnv(cmd, os.Getenv)
+	return SplitCommandEnv(cmd, nil)
 }
 
 // SplitCommandEnv parses a command and splits it into lexical
@@ -21,9 +21,16 @@ func SplitCommand(cmd string) []string {
 // function that will be used when expanding values within the parsed
 // arguments.
 func SplitCommandEnv(cmd string, getenv func(key string) string) []string {
-	parts, err := shlex.Split(strings.TrimSpace(strings.Trim(os.Expand(cmd, getenv), "`")))
+	parts, err := shlex.Split(strings.TrimSpace(cmd))
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if getenv != nil {
+		for i, p := range parts {
+			parts[i] = os.Expand(p, getenv)
+		}
+	}
+
 	return parts
 }

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,8 +1,6 @@
 package procs_test
 
 import (
-	"fmt"
-	"os"
 	"testing"
 
 	"github.com/apoydence/onpar"
@@ -29,20 +27,6 @@ func TestSplitCommand(t *testing.T) {
 		})
 
 		o.Spec("pass with a pipe", matchSplitCommand)
-	})
-
-	o.Group("replace with os environment", func() {
-		o.BeforeEach(func(t *testing.T) (*testing.T, []string, []string) {
-			envvar := "PROCS_SPLIT_ENVVAR_TEST"
-			os.Setenv(envvar, "bar")
-
-			parts := procs.SplitCommand(fmt.Sprintf("echo ${%s}", envvar))
-
-			expected := []string{"echo", "bar"}
-			return t, parts, expected
-		})
-
-		o.Spec("expand values found in env", matchSplitCommand)
 	})
 
 	o.Group("replace with specific context", func() {

--- a/process.go
+++ b/process.go
@@ -87,12 +87,8 @@ func NewProcess(command string) *Process {
 	return &Process{CmdString: command}
 }
 
-// internal expand method to use the os env or proc env.
+// internal expand method to use the proc env.
 func (p *Process) expand(s string) string {
-	if p.Env != nil {
-		return os.ExpandEnv(s)
-	}
-
 	return os.Expand(s, func(key string) string {
 		v, _ := p.Env[key]
 		return v


### PR DESCRIPTION
In addition to the documentation updates, this changes the default
behavior to prefer **not** using the parent process environment by
default and requiring an explicit `map[string]string` be used. I also
pointed out the helper functions that can make it easier to use the
parent environment, assuming that is what the user wants.

Fixes: #3