### PR TITLE
update dependency: github.com/apoydence/onpar -> github.com/poy/onpar

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,7 +23,7 @@
 
 [[constraint]]
   branch = "master"
-  name = "github.com/apoydence/onpar"
+  name = "github.com/poy/onpar"
 
 [[constraint]]
   branch = "master"

--- a/parse_test.go
+++ b/parse_test.go
@@ -3,9 +3,9 @@ package procs_test
 import (
 	"testing"
 
-	"github.com/apoydence/onpar"
-	. "github.com/apoydence/onpar/expect"
-	. "github.com/apoydence/onpar/matchers"
+	"github.com/poy/onpar"
+	. "github.com/poy/onpar/expect"
+	. "github.com/poy/onpar/matchers"
 	"github.com/ionrock/procs"
 )
 


### PR DESCRIPTION
fix: 

imports
        github.com/ionrock/procs tested by
        github.com/ionrock/procs.test imports
        github.com/apoydence/onpar: github.com/apoydence/onpar@v1.0.1: parsing go.mod:
        module declares its path as: github.com/poy/onpar
                but was required as: github.com/apoydence/onpar
